### PR TITLE
Fix: ImportError: No module named _sqlite3

### DIFF
--- a/persistqueue/__init__.py
+++ b/persistqueue/__init__.py
@@ -4,10 +4,13 @@ __license__ = 'BSD'
 __version__ = '0.4.1'
 
 from .exceptions import Empty, Full  # noqa
-from .pdict import PDict  # noqa
 from .queue import Queue  # noqa
-from .sqlqueue import SQLiteQueue, FIFOSQLiteQueue, FILOSQLiteQueue, UniqueQ  # noqa
-from .sqlackqueue import SQLiteAckQueue
+try:
+    from .pdict import PDict  # noqa
+    from .sqlqueue import SQLiteQueue, FIFOSQLiteQueue, FILOSQLiteQueue, UniqueQ  # noqa
+    from .sqlackqueue import SQLiteAckQueue
+except ImportError as error:
+    pass
 
 __all__ = ["Queue", "SQLiteQueue", "FIFOSQLiteQueue", "FILOSQLiteQueue",
            "UniqueQ", "PDict", "SQLiteAckQueue", "Empty", "Full",


### PR DESCRIPTION
I have machines with Freebsd 11.1 and Python 2.7.14. Unfortunately, I can't install the dev bindings (not packaged).

I would like to use the file-based queue functionality.

```
Traceback (most recent call last):
  File "/usr/local/apps/myapp/cron.py", line 9, in <module>
    from persistqueue import Queue
  File "/usr/local/lib/python2.7/site-packages/persistqueue/__init__.py", line 7, in <module>
    from .pdict import PDict  # noqa
  File "/usr/local/lib/python2.7/site-packages/persistqueue/pdict.py", line 4, in <module>
    import sqlite3
  File "/usr/local/lib/python2.7/sqlite3/__init__.py", line 24, in <module>
    from dbapi2 import *
  File "/usr/local/lib/python2.7/sqlite3/dbapi2.py", line 28, in <module>
    from _sqlite3 import *
ImportError: No module named _sqlite3
```

The issue is resolved as I add an ImportError exception.